### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /root
 # copy the mermaidcli node package into the container and install
 COPY ./mermaidcli/* ./
 
-RUN npm install
+RUN npm install && npm cache clean --force;
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update 2>/dev/null && \
@@ -65,7 +65,7 @@ RUN apt-get update 2>/dev/null && \
         xdg-utils \
         wget \
         libxshmfence1 \
-		2>/dev/null
+		2>/dev/null && rm -rf /var/lib/apt/lists/*;
 
 COPY --from=go /root/bin/app ./app
 


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size a bit.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 889.97 MB
* Image size after repair: 861.41 MB
* Difference: 28.56 MB (3.21%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,